### PR TITLE
Use Slice rather than Vec to access expr planners

### DIFF
--- a/datafusion-examples/examples/sql_frontend.rs
+++ b/datafusion-examples/examples/sql_frontend.rs
@@ -136,10 +136,6 @@ struct MyContextProvider {
 }
 
 impl ContextProvider for MyContextProvider {
-    fn get_expr_planners(&self) -> Vec<Arc<dyn datafusion_expr::planner::ExprPlanner>> {
-        vec![]
-    }
-
     fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
         if name.table() == "person" {
             Ok(Arc::new(MyTableSource {

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -503,6 +503,7 @@ impl SessionState {
         let mut provider = SessionContextProvider {
             state: self,
             tables: HashMap::with_capacity(references.len()),
+            expr_planners: self.expr_planners(),
         };
 
         for reference in references {
@@ -567,6 +568,7 @@ impl SessionState {
         let provider = SessionContextProvider {
             state: self,
             tables: HashMap::new(),
+            expr_planners: self.expr_planners(),
         };
 
         let query = SqlToRel::new_with_options(&provider, self.get_parser_options());
@@ -1590,11 +1592,12 @@ impl SessionStateDefaults {
 struct SessionContextProvider<'a> {
     state: &'a SessionState,
     tables: HashMap<String, Arc<dyn TableSource>>,
+    expr_planners: Vec<Arc<dyn ExprPlanner>>,
 }
 
 impl<'a> ContextProvider for SessionContextProvider<'a> {
-    fn get_expr_planners(&self) -> Vec<Arc<dyn ExprPlanner>> {
-        self.state.expr_planners()
+    fn get_expr_planners(&self) -> &[Arc<dyn ExprPlanner>] {
+        &self.expr_planners
     }
 
     fn get_table_source(

--- a/datafusion/core/tests/optimizer_integration.rs
+++ b/datafusion/core/tests/optimizer_integration.rs
@@ -161,10 +161,6 @@ impl MyContextProvider {
 }
 
 impl ContextProvider for MyContextProvider {
-    fn get_expr_planners(&self) -> Vec<Arc<dyn datafusion_expr::planner::ExprPlanner>> {
-        vec![]
-    }
-
     fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
         let table_name = name.table();
         if table_name.starts_with("test") {

--- a/datafusion/expr/src/planner.rs
+++ b/datafusion/expr/src/planner.rs
@@ -61,7 +61,9 @@ pub trait ContextProvider {
     }
 
     /// Getter for expr planners
-    fn get_expr_planners(&self) -> Vec<Arc<dyn ExprPlanner>>;
+    fn get_expr_planners(&self) -> &[Arc<dyn ExprPlanner>] {
+        &[]
+    }
 
     /// Getter for a UDF description
     fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>>;

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -372,10 +372,6 @@ impl MyContextProvider {
 }
 
 impl ContextProvider for MyContextProvider {
-    fn get_expr_planners(&self) -> Vec<Arc<dyn datafusion_expr::planner::ExprPlanner>> {
-        vec![]
-    }
-
     fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
         let table_name = name.table();
         if table_name.starts_with("test") {

--- a/datafusion/sql/examples/sql.rs
+++ b/datafusion/sql/examples/sql.rs
@@ -117,10 +117,6 @@ fn create_table_source(fields: Vec<Field>) -> Arc<dyn TableSource> {
 }
 
 impl ContextProvider for MyContextProvider {
-    fn get_expr_planners(&self) -> Vec<Arc<dyn datafusion_expr::planner::ExprPlanner>> {
-        vec![]
-    }
-
     fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
         match self.tables.get(name.table()) {
             Some(table) => Ok(Arc::clone(table)),

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -979,12 +979,6 @@ mod tests {
     }
 
     impl ContextProvider for TestContextProvider {
-        fn get_expr_planners(
-            &self,
-        ) -> Vec<Arc<dyn datafusion_expr::planner::ExprPlanner>> {
-            vec![]
-        }
-
         fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
             match self.tables.get(name.table()) {
                 Some(table) => Ok(Arc::clone(table)),

--- a/datafusion/sql/tests/common/mod.rs
+++ b/datafusion/sql/tests/common/mod.rs
@@ -76,10 +76,6 @@ impl MockContextProvider {
 }
 
 impl ContextProvider for MockContextProvider {
-    fn get_expr_planners(&self) -> Vec<Arc<dyn datafusion_expr::planner::ExprPlanner>> {
-        vec![]
-    }
-
     fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
         let schema = match name.table() {
             "test" => Ok(Schema::new(vec![


### PR DESCRIPTION
Proposed change to https://github.com/apache/datafusion/pull/11485

This shows how we could use a slice rather than having to copy vectors on each access